### PR TITLE
Add Bitfinex polling using ccxt

### DIFF
--- a/apps/channel/management/commands/bitfinex_polling.py
+++ b/apps/channel/management/commands/bitfinex_polling.py
@@ -1,0 +1,49 @@
+import json
+import logging
+import schedule
+import time
+import ccxt
+
+from django.core.management.base import BaseCommand
+from requests import get, RequestException
+
+from apps.channel.models import ExchangeData
+from apps.channel.models.exchange_data import BITFINEX
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Polls data from Bitfinex every 1 minute"
+
+    def handle(self, *args, **options):
+        logger.info("Getting ready to poll Bitfinex...")
+        schedule.every(1).minutes.do(poll_latest_bitfinex_data)
+
+        keep_going=True
+        while keep_going:
+            try:
+                schedule.run_pending()
+                time.sleep(1)
+            except Exception as e:
+                logger.debug(str(e))
+                logger.info("Bitfinex polling shut down.")
+                keep_going = False
+
+
+def poll_latest_bitfinex_data():
+    try:
+        logger.info("polling for Bitfinex data...")
+        bitfinex = ccxt.bitfinex2()
+        tickers = bitfinex.fetch_tickers()
+        timestamp = float(tickers['BTC/USD']['timestamp']) / 1000
+
+        bitfinex_data_point = ExchangeData.objects.create(
+            source=BITFINEX,
+            data=tickers,
+            timestamp=timestamp
+        )
+        logger.info("Saving Bitfinex data...")
+
+    except RequestException:
+        return 'Error to collect data from Bitfinex'

--- a/apps/channel/models/exchange_data.py
+++ b/apps/channel/models/exchange_data.py
@@ -3,11 +3,12 @@ from django.contrib.postgres.fields import JSONField
 from unixtimestampfield.fields import UnixTimeStampField
 
 
-(POLONIEX, BITTREX, BINANCE) = list(range(3))
+(POLONIEX, BITTREX, BINANCE, BITFINEX) = list(range(4))
 SOURCE_CHOICES = (
     (POLONIEX, 'poloniex'),
     (BITTREX, 'bittrex'),
     (BINANCE, 'binance'),
+    (BITFINEX, 'bitfinex')
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ simplejson==3.11.1
 six==1.11.0
 toolz==0.8.2
 waitress==1.0.1
+ccxt==1.11.1


### PR DESCRIPTION
Adds Bitfinex just like Poliniex polling, using the [Bitfinex v2 REST API](https://bitfinex.readme.io/v2/docs/rest-general). Historical data is not supported by the Bitfinex API, hence not included here.

Using the popular [ccxt](https://ccxt.trade) library for the API communication, that way we'll get a unified format for exchanges implemented with ccxt, while still having access to the raw API response data.

### [Price ticker format](https://github.com/ccxt/ccxt/wiki/Manual#price-tickers)
```
[
  'symbol': {
    'symbol':        string symbol of the market ('BTC/USD', 'ETH/BTC', ...)
    'info':        { the original non-modified unparsed reply from exchange API },
    'timestamp':     int (64-bit Unix Timestamp in milliseconds since Epoch 1 Jan 1970)
    'datetime':      ISO8601 datetime string with milliseconds
    'high':          float, // highest price
    'low':           float, // lowest price
    'bid':           float, // current best bid (buy) price
    'bidVolume':     float, // current best bid (buy) amount
    'ask':           float, // current best ask (sell) price
    'askVolume':     float, // current best ask (sell) amount
    'vwap':          float, // volume weighed average price
    'open':          float, // opening price
    'close':         float, // price of last trade (closing price for current period)
    'last':          float, // same as `close`, duplicated for convenience
    'previousClose': float, // closing price for the previous period
    'change':        float, // absolute change, `last - open`
    'percentage':    float, // relative change, `(change/open) * 100`
    'average':       float, // average price, `(last + open) / 2`
    'baseVolume':    float, // volume of base currency
    'quoteVolume':   float, // volume of quote currency
  },
  'anothersymbol': {...},
  ...
]
```

Values that are not returned by the API are `None` (for Bitfinex those are `open`, `vwap`, `close`, `first`, `average`, `quoteVolume`)

Note on timestamps: The Bitfinex API does not return timestamps, ccxt will add them while parsing the API result. As parsing takes some time the `timestamp` value of each ticker in one call might be different (variance is only 2-3 microsends on my machine). The `ExchangeData` model wants one timestamp for the whole request, so the code will just use one of the tickers' timestamp, it is technically not 100% accurate. I assume an inaccuracy of a few ms is fine.